### PR TITLE
feat: geolocate

### DIFF
--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -25,8 +25,10 @@ jobs:
       - name: Build with trunk
         env:
           PIRATEWEATHER_API_KEY: ${{ secrets.PIRATEWEATHER_API_KEY }}
+          IPLOCATE_API_KEY: ${{ secrets.IPLOCATE_API_KEY}}
         run: |
           export PIRATEWEATHER_API_KEY=${PIRATEWEATHER_API_KEY}
+          export IPLOCATE_API_KEY=${IPLOCATE_API_KEY}
           trunk build --release --public-url /horizon/
 
       - name: Deploy to GitHub Pages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1913,7 +1913,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lib-geolocate"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "gloo-net",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,10 @@ dependencies = [
  "egui_extras",
  "egui_kittest",
  "egui_plot",
+ "gloo-net",
+ "lib-geolocate",
  "lib-weather",
+ "reqwest",
  "serde",
  "time",
  "tokio",
@@ -1907,6 +1910,17 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "lib-geolocate"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "gloo-net",
+ "reqwest",
+ "serde",
+ "tracing",
+]
 
 [[package]]
 name = "lib-weather"
@@ -3140,9 +3154,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
 [workspace.dependencies]
 anyhow = "1.0"
 async-trait = "0.1.88"
+reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1.0.219", features = ["derive"] }
 tracing = { version = "0.1" }
 
@@ -28,6 +29,7 @@ tracing = { version = "0.1" }
 
 # internal
 lib-weather = { path = "lib/weather" }
+lib-geolocate = { path = "lib/geolocate" }
 
 # external
 chrono = { version = "0.4.41" }
@@ -43,17 +45,23 @@ eframe = { version = "0.32.0", default-features = false, features = [
     "wayland",       # To support Linux (and CI)
     "x11",           # To support older Linux distributions (restores one of the default features)
 ] }
-tokio = { version = "1.47.0", features = ["sync", "rt"] }
 time = { version = "0.3", features = ["formatting"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "chrono", "env-filter"] }
 
 # workspace
 anyhow.workspace = true
 serde.workspace = true
+reqwest.workspace = true
 tracing.workspace = true
+
+# native
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.47.0", features = ["sync", "rt-multi-thread"] }
 
 # web
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+gloo-net = "0.6"
+tokio = { version = "1.47.0", features = ["sync", "rt"] }
 wasm-bindgen-futures = "0.4.50"
 web-sys = "0.3.70"              # to access the DOM (to hide the loading text)
 

--- a/lib/geolocate/Cargo.toml
+++ b/lib/geolocate/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "lib-weather"
+name = "lib-geolocate"
 version = "0.1.0"
 authors = ["neuronull"]
 edition = "2021"
@@ -8,7 +8,6 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 tracing.workspace = true

--- a/lib/geolocate/Cargo.toml
+++ b/lib/geolocate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib-geolocate"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["neuronull"]
 edition = "2021"
 rust-version = "1.81"

--- a/lib/geolocate/src/lib.rs
+++ b/lib/geolocate/src/lib.rs
@@ -1,0 +1,69 @@
+use anyhow::Error;
+use serde::Deserialize;
+
+const IPAPI_URL: &str = "https://api.ipgeolocation.io/v2/ipgeo";
+
+#[derive(Default, Debug, Deserialize)]
+pub struct GeoResponse {
+    pub ip: String,
+    pub location: Location,
+    pub country_metadata: CountryMetadata,
+    pub currency: Currency,
+}
+
+#[derive(Default, Debug, Deserialize)]
+pub struct Location {
+    pub continent_code: String,
+    pub continent_name: String,
+    pub country_code2: String,
+    pub country_code3: String,
+    pub country_name: String,
+    pub country_name_official: String,
+    pub country_capital: String,
+    pub state_prov: String,
+    pub state_code: String,
+    pub district: String,
+    pub city: String,
+    pub zipcode: String,
+    pub latitude: String,
+    pub longitude: String,
+    pub is_eu: bool,
+    pub country_flag: String,
+    pub geoname_id: String,
+    pub country_emoji: String,
+}
+
+#[derive(Default, Debug, Deserialize)]
+pub struct CountryMetadata {
+    pub calling_code: String,
+    pub tld: String,
+    pub languages: Vec<String>,
+}
+
+#[derive(Default, Debug, Deserialize)]
+pub struct Currency {
+    pub code: String,
+    pub name: String,
+    pub symbol: String,
+}
+
+pub async fn get_geo_location() -> Result<GeoResponse, Error> {
+    let api_key = env!("IPLOCATE_API_KEY");
+    let url = format!("{IPAPI_URL}?apiKey={api_key}");
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        use gloo_net::http::Request;
+
+        Ok(Request::get(&url)
+            .send()
+            .await?
+            .json::<GeoResponse>()
+            .await?)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        Ok(reqwest::get(url).await?.json::<GeoResponse>().await?)
+    }
+}

--- a/lib/geolocate/src/lib.rs
+++ b/lib/geolocate/src/lib.rs
@@ -48,12 +48,12 @@ pub struct Currency {
 }
 
 pub async fn get_geo_location() -> Result<GeoResponse, Error> {
-    let api_key = env!("IPLOCATE_API_KEY");
-    let url = format!("{IPAPI_URL}?apiKey={api_key}");
-
     #[cfg(target_arch = "wasm32")]
     {
         use gloo_net::http::Request;
+
+        let api_key = env!("IPLOCATE_API_KEY");
+        let url = format!("{IPAPI_URL}?apiKey={api_key}");
 
         Ok(Request::get(&url)
             .send()
@@ -64,6 +64,8 @@ pub async fn get_geo_location() -> Result<GeoResponse, Error> {
 
     #[cfg(not(target_arch = "wasm32"))]
     {
+        let api_key = std::env::var("IPLOCATE_API_KEY")?;
+        let url = format!("{IPAPI_URL}?apiKey={api_key}");
         Ok(reqwest::get(url).await?.json::<GeoResponse>().await?)
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -168,8 +168,7 @@ pub struct AppState {
 
 impl AppState {
     /// Called once before the first frame.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn new(logrx: mpsc::Receiver<String>, rt_handle: &Handle) -> Self {
+    pub fn new(logrx: mpsc::Receiver<String>, rt_handle: Option<&Handle>) -> Self {
         // TODO: re-enable for feature to save state
         // Load previous app state (if any).
         // if let Some(storage) = cc.storage {
@@ -178,25 +177,7 @@ impl AppState {
 
         Self {
             weather_view_selected: true,
-            weather_view: WeatherView::new(rt_handle.clone()),
-            logs_view: LogsView::new(logrx),
-            active_view: View::default(),
-            log_view_selected: false,
-            fetch_state: FetchState::default(),
-        }
-    }
-
-    #[cfg(target_arch = "wasm32")]
-    pub fn new(logrx: mpsc::Receiver<String>) -> Self {
-        // TODO: re-enable for feature to save state
-        // Load previous app state (if any).
-        // if let Some(storage) = cc.storage {
-        //     return eframe::get_value(storage, eframe::APP_KEY).unwrap_or_default();
-        // }
-
-        Self {
-            weather_view_selected: true,
-            weather_view: WeatherView::new(),
+            weather_view: WeatherView::new(rt_handle.cloned()),
             logs_view: LogsView::new(logrx),
             active_view: View::default(),
             log_view_selected: false,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,12 +1,13 @@
+use std::marker::PhantomData;
+
 use anyhow::{Context, Result};
 use eframe::Frame;
 use egui::Context as Ctx;
-use std::marker::PhantomData;
-use tokio::runtime::Handle;
-
-use tokio::runtime::Runtime;
-use tokio::sync::mpsc;
-use tokio::sync::watch::{Receiver, Sender};
+use tokio::runtime::{Handle, Runtime};
+use tokio::sync::{
+    mpsc,
+    watch::{Receiver, Sender},
+};
 use tracing::{error, info};
 
 use super::{LogsView, WeatherView};

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn main() -> eframe::Result {
         .build()
         .expect("Failed to build runtime");
 
-    let state = AppState::new(logrx, runtime.handle());
+    let state = AppState::new(logrx, Some(runtime.handle()));
 
     let native_options = eframe::NativeOptions {
         viewport: egui::ViewportBuilder::default().with_maximized(true),
@@ -48,7 +48,7 @@ fn main() {
     use eframe::wasm_bindgen::JsCast as _;
 
     let logrx = init_logging();
-    let state = AppState::new(logrx);
+    let state = AppState::new(logrx, None);
 
     let web_options = eframe::WebOptions::default();
 

--- a/src/view/weather.rs
+++ b/src/view/weather.rs
@@ -27,27 +27,10 @@ pub struct WeatherView {
 
 impl WeatherView {
     #[must_use]
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn new(rt: Handle) -> Self {
+    pub fn new(rt: Option<Handle>) -> Self {
         let (sender, receiver) = watch::channel(Ok(GeoResponse::default()));
         Self {
-            rt: Some(rt),
-            widgets: Widgets::new(),
-            open_widgets: BTreeSet::new(),
-            latitude_str: String::from(A51_LAT),
-            longitude_str: String::from(A51_LON),
-            location_error_modal_open: false,
-            sender,
-            receiver,
-        }
-    }
-
-    #[must_use]
-    #[cfg(target_arch = "wasm32")]
-    pub fn new() -> Self {
-        let (sender, receiver) = watch::channel(Ok(GeoResponse::default()));
-        Self {
-            rt: None,
+            rt,
             widgets: Widgets::new(),
             open_widgets: BTreeSet::new(),
             latitude_str: String::from(A51_LAT),

--- a/src/view/weather.rs
+++ b/src/view/weather.rs
@@ -1,11 +1,18 @@
 use std::collections::BTreeSet;
 
+use anyhow::Result;
 use egui::{Id, Label, Layout, Modal, ScrollArea, TextEdit, Ui};
+use tokio::{
+    runtime::Handle,
+    sync::watch::{self, Receiver, Sender},
+};
+use tracing::{error, info};
 
 use crate::{FetchState, Widgets, A51_LAT, A51_LON};
+use lib_geolocate::{get_geo_location, GeoResponse};
 
-#[derive(Default)]
 pub struct WeatherView {
+    rt: Option<Handle>,
     /// UI widgets
     pub widgets: Widgets,
     open_widgets: BTreeSet<String>,
@@ -14,20 +21,56 @@ pub struct WeatherView {
     /// location longitude
     pub longitude_str: String,
     pub location_error_modal_open: bool,
+    sender: Sender<Result<GeoResponse>>,
+    receiver: Receiver<Result<GeoResponse>>,
 }
 
 impl WeatherView {
     #[must_use]
-    pub fn new() -> Self {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn new(rt: Handle) -> Self {
+        let (sender, receiver) = watch::channel(Ok(GeoResponse::default()));
         Self {
+            rt: Some(rt),
+            widgets: Widgets::new(),
+            open_widgets: BTreeSet::new(),
             latitude_str: String::from(A51_LAT),
             longitude_str: String::from(A51_LON),
+            location_error_modal_open: false,
+            sender,
+            receiver,
+        }
+    }
+
+    #[must_use]
+    #[cfg(target_arch = "wasm32")]
+    pub fn new() -> Self {
+        let (sender, receiver) = watch::channel(Ok(GeoResponse::default()));
+        Self {
+            rt: None,
             widgets: Widgets::new(),
-            ..Default::default()
+            open_widgets: BTreeSet::new(),
+            latitude_str: String::from(A51_LAT),
+            longitude_str: String::from(A51_LON),
+            location_error_modal_open: false,
+            sender,
+            receiver,
         }
     }
 
     pub fn update(&mut self, ui: &mut Ui, fetch_state: &mut FetchState) {
+        if let Ok(true) = self.receiver.has_changed() {
+            match &*self.receiver.borrow_and_update() {
+                Ok(geo) => {
+                    self.latitude_str = geo.location.latitude.to_owned();
+                    self.longitude_str = geo.location.longitude.to_owned();
+                }
+                Err(err) => {
+                    error!("{err}");
+                }
+            }
+        }
+
         egui::SidePanel::right("right_panel")
             .resizable(false)
             .show(ui.ctx(), |ui| {
@@ -68,14 +111,42 @@ impl WeatherView {
                 ui.add(TextEdit::singleline(&mut self.longitude_str).hint_text(A51_LON));
 
                 ui.end_row();
+
+                if ui.button("Geolocate").clicked() {
+                    self.request_locate();
+                }
+                if ui.button("Fetch").clicked() && *fetch_state == FetchState::Completed {
+                    *fetch_state = FetchState::Requested;
+                }
+                ui.end_row();
             });
 
-        egui::ScrollArea::vertical().show(ui, |ui| {
-            if ui.button("Fetch").clicked() && *fetch_state == FetchState::Completed {
-                *fetch_state = FetchState::Requested;
-            }
-        });
         ui.separator();
+    }
+
+    fn request_locate(&mut self) {
+        info!("Geolocating...");
+        let sender = self.sender.clone();
+
+        cfg_if::cfg_if! {
+            if #[cfg(target_arch = "wasm32")] {
+                wasm_bindgen_futures::spawn_local(async move {
+                    let result = get_geo_location().await;
+                    if let Err(err) = sender.send(result) {
+                        error!("{err}");
+                    } else {
+                        info!("Geolocate success.");
+                    }
+                });
+            } else {
+                let result = self.rt.as_ref().unwrap().block_on(get_geo_location());
+                if let Err(err) = sender.send(result) {
+                    error!("{err}");
+                } else {
+                    info!("Geolocate success.");
+                }
+            }
+        }
     }
 
     fn show_location_error_modal(&mut self, ui: &mut Ui) {


### PR DESCRIPTION
Adds initial support to Geolocate coordinates for weather, based on IP address.
This first version introduces simply a new button that when pressed, triggers the geolocating and the lat/lon are updated accordingly.
In future iterations, it would be nice to have an improved UI for this. 
Improvements:
- tooltip or some way to explain behavior
- indicator of some kind when fetch/geolocate is triggered, to show user it is in progress and either succeeded or failed. as opposed to having to toggle over to the log view. Granted if widgets are open, data would change but a more explicit indicator could be helpful.